### PR TITLE
feature: id() does not go to the database

### DIFF
--- a/src/Contracts/Providers/Auth.php
+++ b/src/Contracts/Providers/Auth.php
@@ -35,4 +35,11 @@ interface Auth
      * @return mixed
      */
     public function user();
+
+    /**
+     * Get the ID of the currently authenticated user.
+     *
+     * @return mixed
+     */
+    public function id();
 }

--- a/src/JWTGuard.php
+++ b/src/JWTGuard.php
@@ -49,6 +49,18 @@ class JWTGuard implements Guard
     protected $request;
 
     /**
+     * The user id.
+     *
+     * @var int|null
+     */
+    protected $id;
+
+    /**
+     * @var bool|null
+     */
+    protected $userNotFound;
+
+    /**
      * Instantiate the class.
      *
      * @param  \Tymon\JWTAuth\JWT  $jwt
@@ -74,12 +86,44 @@ class JWTGuard implements Guard
             return $this->user;
         }
 
+        if (! $this->id()) {
+            return null;
+        }
+
+        return $this->user = $this->provider->retrieveById($this->id());
+    }
+
+    /**
+     * Get the currently authenticated user ID without going to the database.
+     *
+     * @return int|null
+     */
+    public function id()
+    {
+        if ($this->user !== null) {
+            return $this->id = $this->user->getAuthIdentifier();
+        }
+
+        if ($this->id !== null) {
+            return $this->id;
+        }
+
+        if ($this->userNotFound === true) {
+            // If the user was not found, we will not check again.
+            return null;
+        }
+
         if ($this->jwt->setRequest($this->request)->getToken() &&
             ($payload = $this->jwt->check(true)) &&
-            $this->validateSubject()
-        ) {
-            return $this->user = $this->provider->retrieveById($payload['sub']);
+            $this->validateSubject())
+        {
+            $this->id = $payload['sub'];
+            return $this->id;
         }
+
+        $this->userNotFound = true;
+
+        return null;
     }
 
     /**

--- a/src/Providers/Auth/Illuminate.php
+++ b/src/Providers/Auth/Illuminate.php
@@ -65,4 +65,14 @@ class Illuminate implements Auth
     {
         return $this->auth->user();
     }
+
+    /**
+     * Get the ID of the currently authenticated user.
+     *
+     * @return mixed
+     */
+    public function id()
+    {
+        return $this->auth->id();
+    }
 }

--- a/tests/JWTGuardTest.php
+++ b/tests/JWTGuardTest.php
@@ -119,13 +119,13 @@ class JWTGuardTest extends AbstractTestCase
     public function it_should_return_null_if_an_invalid_token_is_provided()
     {
         $this->jwt->shouldReceive('setRequest')->andReturn($this->jwt);
-        $this->jwt->shouldReceive('getToken')->twice()->andReturn('invalid.token.here');
-        $this->jwt->shouldReceive('check')->twice()->andReturn(false);
+        $this->jwt->shouldReceive('getToken')->once()->andReturn('invalid.token.here'); // We don't call it twice.
+        $this->jwt->shouldReceive('check')->once()->andReturn(false);
         $this->jwt->shouldReceive('getPayload->get')->never();
         $this->provider->shouldReceive('retrieveById')->never();
 
         $this->assertNull($this->guard->user()); // once
-        $this->assertFalse($this->guard->check()); // twice
+        $this->assertFalse($this->guard->check()); // second time, but now it's cached.
     }
 
     /** @test */
@@ -148,8 +148,8 @@ class JWTGuardTest extends AbstractTestCase
         $this->expectExceptionMessage('An error occurred');
 
         $this->jwt->shouldReceive('setRequest')->andReturn($this->jwt);
-        $this->jwt->shouldReceive('getToken')->twice()->andReturn('invalid.token.here');
-        $this->jwt->shouldReceive('check')->twice()->andReturn(false);
+        $this->jwt->shouldReceive('getToken')->once()->andReturn('invalid.token.here');
+        $this->jwt->shouldReceive('check')->once()->andReturn(false);
         $this->jwt->shouldReceive('getPayload->get')->never();
         $this->provider->shouldReceive('retrieveById')->never();
 


### PR DESCRIPTION
+ `auth()->id()` used to be an alias for `auth()->user()->id`, but that means it would always go to the database to get the `id`. Now it doesn't need to, It reads it from the JWT.
+ `id() `is now memoized. Calling `->id()` multiple times parses the JWT only once.

**note:** memoization could be done more intensively